### PR TITLE
replace PLAIN with OAUTHBEARER

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ hs_err_pid*
 dependency-reduced-pom.xml
 java/*/target/*
 java/*/target/*.*
+
+.DS_Store

--- a/java-apache/01-kafka-intro/consumer/.gitignore
+++ b/java-apache/01-kafka-intro/consumer/.gitignore
@@ -1,1 +1,2 @@
 /target/
+oauth-client/

--- a/java-apache/01-kafka-intro/consumer/pom.xml
+++ b/java-apache/01-kafka-intro/consumer/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.eventstreams</groupId>
             <artifactId>oauth-client</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
 
         <dependency>

--- a/java-apache/01-kafka-intro/consumer/pom.xml
+++ b/java-apache/01-kafka-intro/consumer/pom.xml
@@ -17,7 +17,13 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.1.0</version>
+            <version>3.3.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.eventstreams</groupId>
+            <artifactId>oauth-client</artifactId>
+            <version>0.1.1</version>
         </dependency>
 
         <dependency>

--- a/java-apache/01-kafka-intro/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
+++ b/java-apache/01-kafka-intro/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
@@ -48,7 +48,7 @@ public class ConsumerConfiguration {
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
         configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=\"%s\";",
                 args.apikey));
         configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
                 "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");

--- a/java-apache/01-kafka-intro/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
+++ b/java-apache/01-kafka-intro/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
@@ -22,31 +22,47 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
 /**
- * ConsumerConfiguration creates the configuration for the Apache Kafka consumer client.
- * See https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-consuming_messages for
+ * ConsumerConfiguration creates the configuration for the Apache Kafka consumer
+ * client.
+ * See
+ * https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-consuming_messages
+ * for
  * more information on configuring consumers for use with Event Streams.
  */
 public class ConsumerConfiguration {
 
-	public static Properties makeConfiguration(ConsumerCLI args) {
-		// The configuration for the apache client is a Properties, with keys defined in the apache client libraries.
-		final Properties configs = new Properties();
+    public static Properties makeConfiguration(ConsumerCLI args) {
+        // The configuration for the apache client is a Properties, with keys defined in
+        // the apache client libraries.
+        final Properties configs = new Properties();
 
-		// To access the kafka servers, we need to authenticate using SASL_SSL and the apikey,
-		// and provide the bootstrap server list
+        // To access the kafka servers, we need to authenticate using SASL_SSL and the
+        // apikey, and provide the bootstrap server list
+
+        // SASL_MECHANISM=PLAIN via API key is deprecated, use OAUTHBEARER instead
+        // configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+        // configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        // configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
+        // "org.apache.kafka.common.security.plain.PlainLoginModule required
+        // username=\"token\" password=\"%s\";", args.apikey));
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-        configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"token\" password=\"%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
                 args.apikey));
+        configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+                "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/token");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/keys");
         configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, args.bootstrapServers);
 
         // Set up the recommended Event Streams kafka consumer configuration
-        // The client ID identifies your client application, and appears in the kafka server logs.
+        // The client ID identifies your client application, and appears in the kafka
+        // server logs.
         configs.put(CommonClientConfigs.CLIENT_ID_CONFIG, "eventstreams-java-sample-consumer0");
-        
-        // Each consumer is a member of a consumer group, identified by a string (command-line argument
-        // in this sample).
+
+        // Each consumer is a member of a consumer group, identified by a string
+        // (command-line argument in this sample).
         configs.put(ConsumerConfig.GROUP_ID_CONFIG, args.consumerGroup);
 
         // Part of the consumer's configuration is the classes to use for deserializing
@@ -54,7 +70,7 @@ public class ConsumerConfiguration {
         // In this sample, we'll assume that the records contain strings.
         configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-	        
-	    return configs;
-	}
+
+        return configs;
+    }
 }

--- a/java-apache/01-kafka-intro/producer/.gitignore
+++ b/java-apache/01-kafka-intro/producer/.gitignore
@@ -1,1 +1,2 @@
 /target/
+oauth-client/

--- a/java-apache/01-kafka-intro/producer/pom.xml
+++ b/java-apache/01-kafka-intro/producer/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.eventstreams</groupId>
             <artifactId>oauth-client</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
 
         <dependency>

--- a/java-apache/01-kafka-intro/producer/pom.xml
+++ b/java-apache/01-kafka-intro/producer/pom.xml
@@ -17,7 +17,13 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.1.0</version>
+            <version>3.3.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.eventstreams</groupId>
+            <artifactId>oauth-client</artifactId>
+            <version>0.1.1</version>
         </dependency>
 
         <dependency>

--- a/java-apache/01-kafka-intro/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
+++ b/java-apache/01-kafka-intro/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.ibm.eventstreams;
 
 import java.util.Properties;
@@ -23,52 +22,74 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 /**
- * ProducerConfiguration creates the configuration for the Apache Kafka producer client.
- * See https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-producing_messages for
+ * ProducerConfiguration creates the configuration for the Apache Kafka producer
+ * client.
+ * See
+ * https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-producing_messages
+ * for
  * more information on configuring producers for use with Event Streams.
  */
 public class ProducerConfiguration {
-	
-	static Properties makeConfiguration(ProducerCLI args) {
-		// The configuration for the apache client is a Properties, with keys defined in the apache client libraries.
-		final Properties configs = new Properties();
-		
-		// To access the kafka servers, we need to authenticate using SASL_SSL and the apikey,
-		// and provide the bootstrap server list
+
+    static Properties makeConfiguration(ProducerCLI args) {
+        // The configuration for the apache client is a Properties, with keys defined in
+        // the apache client libraries.
+        final Properties configs = new Properties();
+
+        // To access the kafka servers, we need to authenticate using SASL_SSL and the
+        // apikey, and provide the bootstrap server list
+
+        // SASL_MECHANISM=PLAIN via API key is deprecated, use OAUTHBEARER instead
+        // configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+        // configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        // configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
+        // "org.apache.kafka.common.security.plain.PlainLoginModule required
+        // username=\"token\" password=\"%s\";", args.apikey));
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-        configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"token\" password=\"%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
                 args.apikey));
+        configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+                "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/token");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/keys");
         configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, args.bootstrapServers);
 
         // Set up the recommended Event Streams kafka producer configuration
-        // The client ID identifies your client application, and appears in the kafka server logs.
+        // The client ID identifies your client application, and appears in the kafka
+        // server logs.
         configs.put(CommonClientConfigs.CLIENT_ID_CONFIG, "eventstreams-java-sample-producer0");
-        // Setting acks to "all" means that the kafka server will not acknowledge receipt of a message until
-        // it has been distributed to all the brokers that are replicating the message. This is the strongest 
+        // Setting acks to "all" means that the kafka server will not acknowledge
+        // receipt of a message until
+        // it has been distributed to all the brokers that are replicating the message.
+        // This is the strongest
         // guarantee that messages will not be lost.
         configs.put(ProducerConfig.ACKS_CONFIG, "all");
-        // Setting retries to a non-zero value means that the apache client will try to resend messages
-        // on transient errors. This reduces the need for retry logic in the producer code/
+        // Setting retries to a non-zero value means that the apache client will try to
+        // resend messages
+        // on transient errors. This reduces the need for retry logic in the producer
+        // code/
         configs.put(ProducerConfig.RETRIES_CONFIG, 2147483647);
-        // Setting idempotence to true means that the apache client will guarantee that message send retries
+        // Setting idempotence to true means that the apache client will guarantee that
+        // message send retries
         // will not result in duplication of messages.
         configs.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
-        // With idempotence set to true, we must also configure the in-flight requests per connection to 5 or less.
+        // With idempotence set to true, we must also configure the in-flight requests
+        // per connection to 5 or less.
         configs.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
-        
+
         // The client can compress message data before it is transmitted. Typically the
         // trade-off between CPU and network bandwidth used makes this worthwhile.
         configs.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");
-        
+
         // Part of the producer's configuration is the classes to use for serializing
         // data into the records (message) that are sent from the client to Kafka.
         // In this sample, our keys and messages will both be strings.
         configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-		
-		return configs;
-	}
+
+        return configs;
+    }
 
 }

--- a/java-apache/01-kafka-intro/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
+++ b/java-apache/01-kafka-intro/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
@@ -48,7 +48,7 @@ public class ProducerConfiguration {
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
         configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=\"%s\";",
                 args.apikey));
         configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
                 "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");

--- a/java-apache/02-sample/consumer/.gitignore
+++ b/java-apache/02-sample/consumer/.gitignore
@@ -1,1 +1,2 @@
 /target/
+oauth-client/

--- a/java-apache/02-sample/consumer/pom.xml
+++ b/java-apache/02-sample/consumer/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.eventstreams</groupId>
             <artifactId>oauth-client</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
 
         <dependency>

--- a/java-apache/02-sample/consumer/pom.xml
+++ b/java-apache/02-sample/consumer/pom.xml
@@ -17,7 +17,13 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.1.0</version>
+            <version>3.3.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.eventstreams</groupId>
+            <artifactId>oauth-client</artifactId>
+            <version>0.1.1</version>
         </dependency>
 
         <dependency>

--- a/java-apache/02-sample/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
+++ b/java-apache/02-sample/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
@@ -47,7 +47,7 @@ public class ConsumerConfiguration {
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
         configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=\"%s\";",
                 args.apikey));
         configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
                 "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");

--- a/java-apache/02-sample/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
+++ b/java-apache/02-sample/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
@@ -22,39 +22,55 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
 /**
- * ConsumerConfiguration creates the configuration for the Apache Kafka consumer client.
- * See https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-consuming_messages for
- * more information on configuring consumers for use with Event Streams.
+ * ConsumerConfiguration creates the configuration for the Apache Kafka consumer
+ * client.
+ * See
+ * https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-consuming_messages
+ * for more information on configuring consumers for use with Event Streams.
  */
 public class ConsumerConfiguration {
 
-	public static Properties makeConfiguration(ConsumerCLI args) {
-		// The configuration for the apache client is a Properties, with keys defined in the apache client libraries.
-		final Properties configs = new Properties();
+    public static Properties makeConfiguration(ConsumerCLI args) {
+        // The configuration for the apache client is a Properties, with keys defined in
+        // the apache client libraries.
+        final Properties configs = new Properties();
 
-		// To access the kafka servers, we need to authenticate using SASL_SSL and the apikey,
-		// and provide the bootstrap server list
+        // To access the kafka servers, we need to authenticate using SASL_SSL and the
+        // apikey, and provide the bootstrap server list
+
+        // SASL_MECHANISM=PLAIN via API key is deprecated, use OAUTHBEARER instead
+        // configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+        // configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        // configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
+        // "org.apache.kafka.common.security.plain.PlainLoginModule required
+        // username=\"token\" password=\"%s\";", args.apikey));
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-        configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"token\" password=\"%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
                 args.apikey));
+        configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+                "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/token");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/keys");
         configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, args.bootstrapServers);
 
         // Set up the recommended Event Streams kafka consumer configuration
-        // The client ID identifies your client application, and appears in the kafka server logs.
+        // The client ID identifies your client application, and appears in the kafka
+        // server logs.
         configs.put(CommonClientConfigs.CLIENT_ID_CONFIG, "eventstreams-java-sample-consumer1");
-        
-        // Each consumer is a member of a consumer group, identified by a string (command-line argument
+
+        // Each consumer is a member of a consumer group, identified by a string
+        // (command-line argument
         // in this sample).
-	    configs.put(ConsumerConfig.GROUP_ID_CONFIG, args.consumerGroup);
-	    
+        configs.put(ConsumerConfig.GROUP_ID_CONFIG, args.consumerGroup);
+
         // Part of the consumer's configuration is the classes to use for deserializing
         // data from the records (message) that are received by this consumer.
         // In this sample, we'll assume that the records contain strings.
         configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-	        
-	    return configs;
-	}
+
+        return configs;
+    }
 }

--- a/java-apache/02-sample/producer/.gitignore
+++ b/java-apache/02-sample/producer/.gitignore
@@ -1,1 +1,2 @@
 /target/
+oauth-client/

--- a/java-apache/02-sample/producer/pom.xml
+++ b/java-apache/02-sample/producer/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.eventstreams</groupId>
             <artifactId>oauth-client</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
 
         <dependency>

--- a/java-apache/02-sample/producer/pom.xml
+++ b/java-apache/02-sample/producer/pom.xml
@@ -17,7 +17,13 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.1.0</version>
+            <version>3.3.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.eventstreams</groupId>
+            <artifactId>oauth-client</artifactId>
+            <version>0.1.1</version>
         </dependency>
 
         <dependency>

--- a/java-apache/02-sample/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
+++ b/java-apache/02-sample/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.ibm.eventstreams;
 
 import java.util.Properties;
@@ -23,52 +22,74 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 /**
- * ProducerConfiguration creates the configuration for the Apache Kafka producer client.
- * See https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-producing_messages for
+ * ProducerConfiguration creates the configuration for the Apache Kafka producer
+ * client.
+ * See
+ * https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-producing_messages
+ * for
  * more information on configuring producers for use with Event Streams.
  */
 public class ProducerConfiguration {
-	
-	static Properties makeConfiguration(ProducerCLI args) {
-		// The configuration for the apache client is a Properties, with keys defined in the apache client libraries.
-		final Properties configs = new Properties();
-		
-		// To access the kafka servers, we need to authenticate using SASL_SSL and the apikey,
-		// and provide the bootstrap server list
+
+    static Properties makeConfiguration(ProducerCLI args) {
+        // The configuration for the apache client is a Properties, with keys defined in
+        // the apache client libraries.
+        final Properties configs = new Properties();
+
+        // To access the kafka servers, we need to authenticate using SASL_SSL and the
+        // apikey, and provide the bootstrap server list
+
+        // SASL_MECHANISM=PLAIN via API key is deprecated, use OAUTHBEARER instead
+        // configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+        // configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        // configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
+        // "org.apache.kafka.common.security.plain.PlainLoginModule required
+        // username=\"token\" password=\"%s\";", args.apikey));
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-        configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"token\" password=\"%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
                 args.apikey));
+        configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+                "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/token");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/keys");
         configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, args.bootstrapServers);
 
         // Set up the recommended Event Streams kafka producer configuration
-        // The client ID identifies your client application, and appears in the kafka server logs.
+        // The client ID identifies your client application, and appears in the kafka
+        // server logs.
         configs.put(CommonClientConfigs.CLIENT_ID_CONFIG, "eventstreams-java-sample-producer1");
-        // Setting acks to "all" means that the kafka server will not acknowledge receipt of a message until
-        // it has been distributed to all the brokers that are replicating the message. This is the strongest 
+        // Setting acks to "all" means that the kafka server will not acknowledge
+        // receipt of a message until
+        // it has been distributed to all the brokers that are replicating the message.
+        // This is the strongest
         // guarantee that messages will not be lost.
         configs.put(ProducerConfig.ACKS_CONFIG, "all");
-        // Setting retries to a non-zero value means that the apache client will try to resend messages
-        // on transient errors. This reduces the need for retry logic in the producer code/
+        // Setting retries to a non-zero value means that the apache client will try to
+        // resend messages
+        // on transient errors. This reduces the need for retry logic in the producer
+        // code/
         configs.put(ProducerConfig.RETRIES_CONFIG, 2147483647);
-        // Setting idempotence to true means that the apache client will guarantee that message send retries
+        // Setting idempotence to true means that the apache client will guarantee that
+        // message send retries
         // will not result in duplication of messages.
         configs.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
-        // With idempotence set to true, we must also configure the in-flight requests per connection to 5 or less.
+        // With idempotence set to true, we must also configure the in-flight requests
+        // per connection to 5 or less.
         configs.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
-        
+
         // The client can compress message data before it is transmitted. Typically the
         // trade-off between CPU and network bandwidth used makes this worthwhile.
         configs.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");
-        
+
         // Part of the producer's configuration is the classes to use for serializing
         // data into the records (message) that are sent from the client to Kafka.
         // In this sample, our keys and messages will both be strings.
         configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-		
-		return configs;
-	}
+
+        return configs;
+    }
 
 }

--- a/java-apache/02-sample/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
+++ b/java-apache/02-sample/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
@@ -48,7 +48,7 @@ public class ProducerConfiguration {
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
         configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=\"%s\";",
                 args.apikey));
         configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
                 "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");

--- a/java-apache/03-topics/topics/.gitignore
+++ b/java-apache/03-topics/topics/.gitignore
@@ -1,1 +1,2 @@
 /target/
+oauth-client/

--- a/java-apache/03-topics/topics/pom.xml
+++ b/java-apache/03-topics/topics/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.eventstreams</groupId>
             <artifactId>oauth-client</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
 
         <dependency>

--- a/java-apache/03-topics/topics/pom.xml
+++ b/java-apache/03-topics/topics/pom.xml
@@ -17,7 +17,13 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.1.0</version>
+            <version>3.3.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.eventstreams</groupId>
+            <artifactId>oauth-client</artifactId>
+            <version>0.1.1</version>
         </dependency>
 
         <dependency>

--- a/java-apache/03-topics/topics/src/main/java/com/ibm/eventstreams/TopicsConfiguration.java
+++ b/java-apache/03-topics/topics/src/main/java/com/ibm/eventstreams/TopicsConfiguration.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.ibm.eventstreams;
 
 import java.util.Properties;
@@ -21,25 +20,40 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.config.SaslConfigs;
 
 /**
- * TopicsConfiguration creates the configuration for the Apache Kafka admin client.
- * The only required information are the bootstrap servers and the SASL authentication
- * with the apikey. See https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-kafka_java_api
+ * TopicsConfiguration creates the configuration for the Apache Kafka admin
+ * client.
+ * The only required information are the bootstrap servers and the SASL
+ * authentication
+ * with the apikey. See
+ * https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-kafka_java_api
  * for additional information on use of the Kafka administration interface.
  */
 public class TopicsConfiguration {
-	
+
 	static Properties makeConfiguration(TopicsCLI args) {
-		// The configuration for the apache admin client is a Properties, with keys defined in the apache client libraries.
+		// The configuration for the apache admin client is a Properties, with keys
+		// defined in the apache client libraries.
 		final Properties configs = new Properties();
-		
-		// To access the kafka servers, we need to authenticate using SASL_SSL and the apikey,
-		// and provide the bootstrap server list
-        configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-        configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
-        configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"token\" password=\"%s\";",
-                args.apikey));
-        configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, args.bootstrapServers);
+
+		// To access the kafka servers, we need to authenticate using SASL_SSL and the
+		// apikey, and provide the bootstrap server list
+
+		// SASL_MECHANISM=PLAIN via API key is deprecated, use OAUTHBEARER instead
+		// configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+		// configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+		// configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
+		// "org.apache.kafka.common.security.plain.PlainLoginModule required
+		// username=\"token\" password=\"%s\";", args.apikey));
+		configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+		configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
+		configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
+				"org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
+				args.apikey));
+		configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+				"com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");
+		configs.put(SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/token");
+		configs.put(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/keys");
+		configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, args.bootstrapServers);
 
 		return configs;
 	}

--- a/java-apache/03-topics/topics/src/main/java/com/ibm/eventstreams/TopicsConfiguration.java
+++ b/java-apache/03-topics/topics/src/main/java/com/ibm/eventstreams/TopicsConfiguration.java
@@ -47,7 +47,7 @@ public class TopicsConfiguration {
 		configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
 		configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
 		configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-				"org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
+				"org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=\"%s\";",
 				args.apikey));
 		configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
 				"com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");

--- a/java-apache/04-batch/producer/.gitignore
+++ b/java-apache/04-batch/producer/.gitignore
@@ -1,1 +1,2 @@
 /target/
+oauth-client/

--- a/java-apache/04-batch/producer/pom.xml
+++ b/java-apache/04-batch/producer/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.eventstreams</groupId>
             <artifactId>oauth-client</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
 
         <dependency>

--- a/java-apache/04-batch/producer/pom.xml
+++ b/java-apache/04-batch/producer/pom.xml
@@ -17,7 +17,13 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.1.0</version>
+            <version>3.3.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.eventstreams</groupId>
+            <artifactId>oauth-client</artifactId>
+            <version>0.1.1</version>
         </dependency>
 
         <dependency>

--- a/java-apache/04-batch/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
+++ b/java-apache/04-batch/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.ibm.eventstreams;
 
 import java.util.Properties;
@@ -23,52 +22,74 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 /**
- * ProducerConfiguration creates the configuration for the Apache Kafka producer client.
- * See https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-producing_messages for
+ * ProducerConfiguration creates the configuration for the Apache Kafka producer
+ * client.
+ * See
+ * https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-producing_messages
+ * for
  * more information on configuring producers for use with Event Streams.
  */
 public class ProducerConfiguration {
-	
-	static Properties makeConfiguration(ProducerCLI args) {
-		// The configuration for the apache client is a Properties, with keys defined in the apache client libraries.
-		final Properties configs = new Properties();
-		
-		// To access the kafka servers, we need to authenticate using SASL_SSL and the apikey,
-		// and provide the bootstrap server list
+
+    static Properties makeConfiguration(ProducerCLI args) {
+        // The configuration for the apache client is a Properties, with keys defined in
+        // the apache client libraries.
+        final Properties configs = new Properties();
+
+        // To access the kafka servers, we need to authenticate using SASL_SSL and the
+        // apikey, and provide the bootstrap server list
+
+        // SASL_MECHANISM=PLAIN via API key is deprecated, use OAUTHBEARER instead
+        // configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+        // configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        // configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
+        // "org.apache.kafka.common.security.plain.PlainLoginModule required
+        // username=\"token\" password=\"%s\";", args.apikey));
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-        configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"token\" password=\"%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
                 args.apikey));
+        configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+                "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/token");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/keys");
         configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, args.bootstrapServers);
 
         // Set up the recommended Event Streams kafka producer configuration
-        // The client ID identifies your client application, and appears in the kafka server logs.
+        // The client ID identifies your client application, and appears in the kafka
+        // server logs.
         configs.put(CommonClientConfigs.CLIENT_ID_CONFIG, "eventstreams-java-sample-producer1");
-        // Setting acks to "all" means that the kafka server will not acknowledge receipt of a message until
-        // it has been distributed to all the brokers that are replicating the message. This is the strongest 
+        // Setting acks to "all" means that the kafka server will not acknowledge
+        // receipt of a message until
+        // it has been distributed to all the brokers that are replicating the message.
+        // This is the strongest
         // guarantee that messages will not be lost.
         configs.put(ProducerConfig.ACKS_CONFIG, "all");
-        // Setting retries to a non-zero value means that the apache client will try to resend messages
-        // on transient errors. This reduces the need for retry logic in the producer code/
+        // Setting retries to a non-zero value means that the apache client will try to
+        // resend messages
+        // on transient errors. This reduces the need for retry logic in the producer
+        // code/
         configs.put(ProducerConfig.RETRIES_CONFIG, 2147483647);
-        // Setting idempotence to true means that the apache client will guarantee that message send retries
+        // Setting idempotence to true means that the apache client will guarantee that
+        // message send retries
         // will not result in duplication of messages.
         configs.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
-        // With idempotence set to true, we must also configure the in-flight requests per connection to 5 or less.
+        // With idempotence set to true, we must also configure the in-flight requests
+        // per connection to 5 or less.
         configs.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
-        
+
         // The client can compress message data before it is transmitted. Typically the
         // trade-off between CPU and network bandwidth used makes this worthwhile.
         // configs.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");
-        
+
         // Part of the producer's configuration is the classes to use for serializing
         // data into the records (message) that are sent from the client to Kafka.
         // In this sample, our keys and messages will both be strings.
         configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-		
-		return configs;
-	}
+
+        return configs;
+    }
 
 }

--- a/java-apache/04-batch/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
+++ b/java-apache/04-batch/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
@@ -48,7 +48,7 @@ public class ProducerConfiguration {
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
         configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=\"%s\";",
                 args.apikey));
         configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
                 "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");

--- a/java-apache/05-metrics/consumer/.gitignore
+++ b/java-apache/05-metrics/consumer/.gitignore
@@ -1,1 +1,2 @@
 /target/
+oauth-client/

--- a/java-apache/05-metrics/consumer/pom.xml
+++ b/java-apache/05-metrics/consumer/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.eventstreams</groupId>
             <artifactId>oauth-client</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
 
         <dependency>

--- a/java-apache/05-metrics/consumer/pom.xml
+++ b/java-apache/05-metrics/consumer/pom.xml
@@ -17,7 +17,13 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.1.0</version>
+            <version>3.3.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.eventstreams</groupId>
+            <artifactId>oauth-client</artifactId>
+            <version>0.1.1</version>
         </dependency>
 
         <dependency>

--- a/java-apache/05-metrics/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
+++ b/java-apache/05-metrics/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
@@ -22,39 +22,56 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
 /**
- * ConsumerConfiguration creates the configuration for the Apache Kafka consumer client.
- * See https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-consuming_messages for
+ * ConsumerConfiguration creates the configuration for the Apache Kafka consumer
+ * client.
+ * See
+ * https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-consuming_messages
+ * for
  * more information on configuring consumers for use with Event Streams.
  */
 public class ConsumerConfiguration {
 
-	public static Properties makeConfiguration(ConsumerCLI args) {
-		// The configuration for the apache client is a Properties, with keys defined in the apache client libraries.
-		final Properties configs = new Properties();
+    public static Properties makeConfiguration(ConsumerCLI args) {
+        // The configuration for the apache client is a Properties, with keys defined in
+        // the apache client libraries.
+        final Properties configs = new Properties();
 
-		// To access the kafka servers, we need to authenticate using SASL_SSL and the apikey,
-		// and provide the bootstrap server list
+        // To access the kafka servers, we need to authenticate using SASL_SSL and the
+        // apikey, and provide the bootstrap server list
+
+        // SASL_MECHANISM=PLAIN via API key is deprecated, use OAUTHBEARER instead
+        // configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+        // configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        // configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
+        // "org.apache.kafka.common.security.plain.PlainLoginModule required
+        // username=\"token\" password=\"%s\";", args.apikey));
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-        configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"token\" password=\"%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
                 args.apikey));
+        configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+                "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/token");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/keys");
         configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, args.bootstrapServers);
 
         // Set up the recommended Event Streams kafka consumer configuration
-        // The client ID identifies your client application, and appears in the kafka server logs.
+        // The client ID identifies your client application, and appears in the kafka
+        // server logs.
         configs.put(CommonClientConfigs.CLIENT_ID_CONFIG, "eventstreams-java-sample-consumer1");
-        
-        // Each consumer is a member of a consumer group, identified by a string (command-line argument
+
+        // Each consumer is a member of a consumer group, identified by a string
+        // (command-line argument
         // in this sample).
-	    configs.put(ConsumerConfig.GROUP_ID_CONFIG, args.consumerGroup);
-	    
+        configs.put(ConsumerConfig.GROUP_ID_CONFIG, args.consumerGroup);
+
         // Part of the consumer's configuration is the classes to use for deserializing
         // data from the records (message) that are received by this consumer.
         // In this sample, we'll assume that the records contain strings.
         configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-	        
-	    return configs;
-	}
+
+        return configs;
+    }
 }

--- a/java-apache/05-metrics/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
+++ b/java-apache/05-metrics/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
@@ -48,7 +48,7 @@ public class ConsumerConfiguration {
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
         configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=\"%s\";",
                 args.apikey));
         configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
                 "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");

--- a/java-apache/05-metrics/producer/.gitignore
+++ b/java-apache/05-metrics/producer/.gitignore
@@ -1,1 +1,2 @@
 /target/
+oauth-client/

--- a/java-apache/05-metrics/producer/pom.xml
+++ b/java-apache/05-metrics/producer/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.eventstreams</groupId>
             <artifactId>oauth-client</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
 
         <dependency>

--- a/java-apache/05-metrics/producer/pom.xml
+++ b/java-apache/05-metrics/producer/pom.xml
@@ -17,7 +17,13 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.1.0</version>
+            <version>3.3.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.eventstreams</groupId>
+            <artifactId>oauth-client</artifactId>
+            <version>0.1.1</version>
         </dependency>
 
         <dependency>

--- a/java-apache/05-metrics/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
+++ b/java-apache/05-metrics/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.ibm.eventstreams;
 
 import java.util.Properties;
@@ -23,52 +22,74 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 /**
- * ProducerConfiguration creates the configuration for the Apache Kafka producer client.
- * See https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-producing_messages for
+ * ProducerConfiguration creates the configuration for the Apache Kafka producer
+ * client.
+ * See
+ * https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-producing_messages
+ * for
  * more information on configuring producers for use with Event Streams.
  */
 public class ProducerConfiguration {
-	
-	static Properties makeConfiguration(ProducerCLI args) {
-		// The configuration for the apache client is a Properties, with keys defined in the apache client libraries.
-		final Properties configs = new Properties();
-		
-		// To access the kafka servers, we need to authenticate using SASL_SSL and the apikey,
-		// and provide the bootstrap server list
+
+    static Properties makeConfiguration(ProducerCLI args) {
+        // The configuration for the apache client is a Properties, with keys defined in
+        // the apache client libraries.
+        final Properties configs = new Properties();
+
+        // To access the kafka servers, we need to authenticate using SASL_SSL and the
+        // apikey, and provide the bootstrap server list
+
+        // SASL_MECHANISM=PLAIN via API key is deprecated, use OAUTHBEARER instead
+        // configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+        // configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        // configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
+        // "org.apache.kafka.common.security.plain.PlainLoginModule required
+        // username=\"token\" password=\"%s\";", args.apikey));
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-        configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"token\" password=\"%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
                 args.apikey));
+        configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+                "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/token");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/keys");
         configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, args.bootstrapServers);
 
         // Set up the recommended Event Streams kafka producer configuration
-        // The client ID identifies your client application, and appears in the kafka server logs.
+        // The client ID identifies your client application, and appears in the kafka
+        // server logs.
         configs.put(CommonClientConfigs.CLIENT_ID_CONFIG, "eventstreams-java-sample-producer1");
-        // Setting acks to "all" means that the kafka server will not acknowledge receipt of a message until
-        // it has been distributed to all the brokers that are replicating the message. This is the strongest 
+        // Setting acks to "all" means that the kafka server will not acknowledge
+        // receipt of a message until
+        // it has been distributed to all the brokers that are replicating the message.
+        // This is the strongest
         // guarantee that messages will not be lost.
         configs.put(ProducerConfig.ACKS_CONFIG, "all");
-        // Setting retries to a non-zero value means that the apache client will try to resend messages
-        // on transient errors. This reduces the need for retry logic in the producer code/
+        // Setting retries to a non-zero value means that the apache client will try to
+        // resend messages
+        // on transient errors. This reduces the need for retry logic in the producer
+        // code/
         configs.put(ProducerConfig.RETRIES_CONFIG, 2147483647);
-        // Setting idempotence to true means that the apache client will guarantee that message send retries
+        // Setting idempotence to true means that the apache client will guarantee that
+        // message send retries
         // will not result in duplication of messages.
         configs.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
-        // With idempotence set to true, we must also configure the in-flight requests per connection to 5 or less.
+        // With idempotence set to true, we must also configure the in-flight requests
+        // per connection to 5 or less.
         configs.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
-        
+
         // The client can compress message data before it is transmitted. Typically the
         // trade-off between CPU and network bandwidth used makes this worthwhile.
         configs.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");
-        
+
         // Part of the producer's configuration is the classes to use for serializing
         // data into the records (message) that are sent from the client to Kafka.
         // In this sample, our keys and messages will both be strings.
         configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-		
-		return configs;
-	}
+
+        return configs;
+    }
 
 }

--- a/java-apache/05-metrics/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
+++ b/java-apache/05-metrics/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
@@ -48,7 +48,7 @@ public class ProducerConfiguration {
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
         configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=\"%s\";",
                 args.apikey));
         configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
                 "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");

--- a/java-apache/06-pause-resume/consumer/.gitignore
+++ b/java-apache/06-pause-resume/consumer/.gitignore
@@ -1,1 +1,2 @@
 /target/
+oauth-client/

--- a/java-apache/06-pause-resume/consumer/pom.xml
+++ b/java-apache/06-pause-resume/consumer/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.eventstreams</groupId>
             <artifactId>oauth-client</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
 
         <dependency>

--- a/java-apache/06-pause-resume/consumer/pom.xml
+++ b/java-apache/06-pause-resume/consumer/pom.xml
@@ -17,7 +17,13 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.1.0</version>
+            <version>3.3.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.eventstreams</groupId>
+            <artifactId>oauth-client</artifactId>
+            <version>0.1.1</version>
         </dependency>
 
         <dependency>

--- a/java-apache/06-pause-resume/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
+++ b/java-apache/06-pause-resume/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
@@ -22,42 +22,60 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
 /**
- * ConsumerConfiguration creates the configuration for the Apache Kafka consumer client.
- * See https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-consuming_messages for
+ * ConsumerConfiguration creates the configuration for the Apache Kafka consumer
+ * client.
+ * See
+ * https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-consuming_messages
+ * for
  * more information on configuring consumers for use with Event Streams.
  */
 public class ConsumerConfiguration {
 
-	public static Properties makeConfiguration(ConsumerCLI args) {
-		// The configuration for the apache client is a Properties, with keys defined in the apache client libraries.
-		final Properties configs = new Properties();
+    public static Properties makeConfiguration(ConsumerCLI args) {
+        // The configuration for the apache client is a Properties, with keys defined in
+        // the apache client libraries.
+        final Properties configs = new Properties();
 
-		// To access the kafka servers, we need to authenticate using SASL_SSL and the apikey,
-		// and provide the bootstrap server list
+        // To access the kafka servers, we need to authenticate using SASL_SSL and the
+        // apikey, and provide the bootstrap server list
+
+        // SASL_MECHANISM=PLAIN via API key is deprecated, use OAUTHBEARER instead
+        // configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+        // configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        // configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
+        // "org.apache.kafka.common.security.plain.PlainLoginModule required
+        // username=\"token\" password=\"%s\";", args.apikey));
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-        configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"token\" password=\"%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
                 args.apikey));
+        configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+                "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/token");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/keys");
         configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, args.bootstrapServers);
 
         // Set up the recommended Event Streams kafka consumer configuration
-        // The client ID identifies your client application, and appears in the kafka server logs.
+        // The client ID identifies your client application, and appears in the kafka
+        // server logs.
         configs.put(CommonClientConfigs.CLIENT_ID_CONFIG, "eventstreams-java-sample-consumer1");
-        
-        // Each consumer is a member of a consumer group, identified by a string (command-line argument
+
+        // Each consumer is a member of a consumer group, identified by a string
+        // (command-line argument
         // in this sample).
-	    configs.put(ConsumerConfig.GROUP_ID_CONFIG, args.consumerGroup);
-	    
-        // For this sample, new consumer groups will start reading messages at the earliest available offset.
+        configs.put(ConsumerConfig.GROUP_ID_CONFIG, args.consumerGroup);
+
+        // For this sample, new consumer groups will start reading messages at the
+        // earliest available offset.
         configs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-	    
+
         // Part of the consumer's configuration is the classes to use for deserializing
         // data from the records (message) that are received by this consumer.
         // In this sample, we'll assume that the records contain strings.
         configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-	        
-	    return configs;
-	}
+
+        return configs;
+    }
 }

--- a/java-apache/06-pause-resume/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
+++ b/java-apache/06-pause-resume/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
@@ -48,7 +48,7 @@ public class ConsumerConfiguration {
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
         configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=\"%s\";",
                 args.apikey));
         configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
                 "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");

--- a/java-apache/06-pause-resume/producer/.gitignore
+++ b/java-apache/06-pause-resume/producer/.gitignore
@@ -1,1 +1,2 @@
 /target/
+oauth-client/

--- a/java-apache/06-pause-resume/producer/pom.xml
+++ b/java-apache/06-pause-resume/producer/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.eventstreams</groupId>
             <artifactId>oauth-client</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
 
         <dependency>

--- a/java-apache/06-pause-resume/producer/pom.xml
+++ b/java-apache/06-pause-resume/producer/pom.xml
@@ -17,7 +17,13 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.1.0</version>
+            <version>3.3.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.eventstreams</groupId>
+            <artifactId>oauth-client</artifactId>
+            <version>0.1.1</version>
         </dependency>
 
         <dependency>

--- a/java-apache/06-pause-resume/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
+++ b/java-apache/06-pause-resume/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.ibm.eventstreams;
 
 import java.util.Properties;
@@ -23,52 +22,74 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 /**
- * ProducerConfiguration creates the configuration for the Apache Kafka producer client.
- * See https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-producing_messages for
+ * ProducerConfiguration creates the configuration for the Apache Kafka producer
+ * client.
+ * See
+ * https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-producing_messages
+ * for
  * more information on configuring producers for use with Event Streams.
  */
 public class ProducerConfiguration {
-	
-	static Properties makeConfiguration(ProducerCLI args) {
-		// The configuration for the apache client is a Properties, with keys defined in the apache client libraries.
-		final Properties configs = new Properties();
-		
-		// To access the kafka servers, we need to authenticate using SASL_SSL and the apikey,
-		// and provide the bootstrap server list
+
+    static Properties makeConfiguration(ProducerCLI args) {
+        // The configuration for the apache client is a Properties, with keys defined in
+        // the apache client libraries.
+        final Properties configs = new Properties();
+
+        // To access the kafka servers, we need to authenticate using SASL_SSL and the
+        // apikey, and provide the bootstrap server list
+
+        // SASL_MECHANISM=PLAIN via API key is deprecated, use OAUTHBEARER instead
+        // configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+        // configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        // configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
+        // "org.apache.kafka.common.security.plain.PlainLoginModule required
+        // username=\"token\" password=\"%s\";", args.apikey));
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-        configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"token\" password=\"%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
                 args.apikey));
+        configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+                "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/token");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/keys");
         configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, args.bootstrapServers);
 
         // Set up the recommended Event Streams kafka producer configuration
-        // The client ID identifies your client application, and appears in the kafka server logs.
+        // The client ID identifies your client application, and appears in the kafka
+        // server logs.
         configs.put(CommonClientConfigs.CLIENT_ID_CONFIG, "eventstreams-java-sample-producer0");
-        // Setting acks to "all" means that the kafka server will not acknowledge receipt of a message until
-        // it has been distributed to all the brokers that are replicating the message. This is the strongest 
+        // Setting acks to "all" means that the kafka server will not acknowledge
+        // receipt of a message until
+        // it has been distributed to all the brokers that are replicating the message.
+        // This is the strongest
         // guarantee that messages will not be lost.
         configs.put(ProducerConfig.ACKS_CONFIG, "all");
-        // Setting retries to a non-zero value means that the apache client will try to resend messages
-        // on transient errors. This reduces the need for retry logic in the producer code/
+        // Setting retries to a non-zero value means that the apache client will try to
+        // resend messages
+        // on transient errors. This reduces the need for retry logic in the producer
+        // code/
         configs.put(ProducerConfig.RETRIES_CONFIG, 2147483647);
-        // Setting idempotence to true means that the apache client will guarantee that message send retries
+        // Setting idempotence to true means that the apache client will guarantee that
+        // message send retries
         // will not result in duplication of messages.
         configs.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
-        // With idempotence set to true, we must also configure the in-flight requests per connection to 5 or less.
+        // With idempotence set to true, we must also configure the in-flight requests
+        // per connection to 5 or less.
         configs.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
-        
+
         // The client can compress message data before it is transmitted. Typically the
         // trade-off between CPU and network bandwidth used makes this worthwhile.
         configs.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");
-        
+
         // Part of the producer's configuration is the classes to use for serializing
         // data into the records (message) that are sent from the client to Kafka.
         // In this sample, our keys and messages will both be strings.
         configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-		
-		return configs;
-	}
+
+        return configs;
+    }
 
 }

--- a/java-apache/06-pause-resume/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
+++ b/java-apache/06-pause-resume/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
@@ -48,7 +48,7 @@ public class ProducerConfiguration {
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
         configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=\"%s\";",
                 args.apikey));
         configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
                 "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");

--- a/java-apache/07-logging/consumer/.gitignore
+++ b/java-apache/07-logging/consumer/.gitignore
@@ -1,1 +1,2 @@
 /target/
+oauth-client/

--- a/java-apache/07-logging/consumer/pom.xml
+++ b/java-apache/07-logging/consumer/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.eventstreams</groupId>
             <artifactId>oauth-client</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
 
         <dependency>

--- a/java-apache/07-logging/consumer/pom.xml
+++ b/java-apache/07-logging/consumer/pom.xml
@@ -17,7 +17,13 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.1.0</version>
+            <version>3.3.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.eventstreams</groupId>
+            <artifactId>oauth-client</artifactId>
+            <version>0.1.1</version>
         </dependency>
 
         <dependency>

--- a/java-apache/07-logging/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
+++ b/java-apache/07-logging/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
@@ -22,39 +22,56 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
 /**
- * ConsumerConfiguration creates the configuration for the Apache Kafka consumer client.
- * See https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-consuming_messages for
+ * ConsumerConfiguration creates the configuration for the Apache Kafka consumer
+ * client.
+ * See
+ * https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-consuming_messages
+ * for
  * more information on configuring consumers for use with Event Streams.
  */
 public class ConsumerConfiguration {
 
-	public static Properties makeConfiguration(ConsumerCLI args) {
-		// The configuration for the apache client is a Properties, with keys defined in the apache client libraries.
-		final Properties configs = new Properties();
+    public static Properties makeConfiguration(ConsumerCLI args) {
+        // The configuration for the apache client is a Properties, with keys defined in
+        // the apache client libraries.
+        final Properties configs = new Properties();
 
-		// To access the kafka servers, we need to authenticate using SASL_SSL and the apikey,
-		// and provide the bootstrap server list
+        // To access the kafka servers, we need to authenticate using SASL_SSL and the
+        // apikey, and provide the bootstrap server list
+
+        // SASL_MECHANISM=PLAIN via API key is deprecated, use OAUTHBEARER instead
+        // configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+        // configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        // configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
+        // "org.apache.kafka.common.security.plain.PlainLoginModule required
+        // username=\"token\" password=\"%s\";", args.apikey));
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-        configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"token\" password=\"%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
                 args.apikey));
+        configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+                "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/token");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/keys");
         configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, args.bootstrapServers);
 
         // Set up the recommended Event Streams kafka consumer configuration
-        // The client ID identifies your client application, and appears in the kafka server logs.
+        // The client ID identifies your client application, and appears in the kafka
+        // server logs.
         configs.put(CommonClientConfigs.CLIENT_ID_CONFIG, "eventstreams-java-sample-consumer1");
-        
-        // Each consumer is a member of a consumer group, identified by a string (command-line argument
+
+        // Each consumer is a member of a consumer group, identified by a string
+        // (command-line argument
         // in this sample).
-	    configs.put(ConsumerConfig.GROUP_ID_CONFIG, args.consumerGroup);
-	    
+        configs.put(ConsumerConfig.GROUP_ID_CONFIG, args.consumerGroup);
+
         // Part of the consumer's configuration is the classes to use for deserializing
         // data from the records (message) that are received by this consumer.
         // In this sample, we'll assume that the records contain strings.
         configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-	        
-	    return configs;
-	}
+
+        return configs;
+    }
 }

--- a/java-apache/07-logging/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
+++ b/java-apache/07-logging/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
@@ -48,7 +48,7 @@ public class ConsumerConfiguration {
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
         configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=\"%s\";",
                 args.apikey));
         configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
                 "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");

--- a/java-apache/07-logging/producer/.gitignore
+++ b/java-apache/07-logging/producer/.gitignore
@@ -1,1 +1,2 @@
 /target/
+oauth-client/

--- a/java-apache/07-logging/producer/pom.xml
+++ b/java-apache/07-logging/producer/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.eventstreams</groupId>
             <artifactId>oauth-client</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
 
         <dependency>

--- a/java-apache/07-logging/producer/pom.xml
+++ b/java-apache/07-logging/producer/pom.xml
@@ -17,7 +17,13 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.1.0</version>
+            <version>3.3.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.eventstreams</groupId>
+            <artifactId>oauth-client</artifactId>
+            <version>0.1.1</version>
         </dependency>
 
         <dependency>

--- a/java-apache/07-logging/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
+++ b/java-apache/07-logging/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.ibm.eventstreams;
 
 import java.util.Properties;
@@ -23,52 +22,74 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 /**
- * ProducerConfiguration creates the configuration for the Apache Kafka producer client.
- * See https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-producing_messages for
+ * ProducerConfiguration creates the configuration for the Apache Kafka producer
+ * client.
+ * See
+ * https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-producing_messages
+ * for
  * more information on configuring producers for use with Event Streams.
  */
 public class ProducerConfiguration {
-	
-	static Properties makeConfiguration(ProducerCLI args) {
-		// The configuration for the apache client is a Properties, with keys defined in the apache client libraries.
-		final Properties configs = new Properties();
-		
-		// To access the kafka servers, we need to authenticate using SASL_SSL and the apikey,
-		// and provide the bootstrap server list
+
+    static Properties makeConfiguration(ProducerCLI args) {
+        // The configuration for the apache client is a Properties, with keys defined in
+        // the apache client libraries.
+        final Properties configs = new Properties();
+
+        // To access the kafka servers, we need to authenticate using SASL_SSL and the
+        // apikey, and provide the bootstrap server list
+
+        // SASL_MECHANISM=PLAIN via API key is deprecated, use OAUTHBEARER instead
+        // configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+        // configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        // configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
+        // "org.apache.kafka.common.security.plain.PlainLoginModule required
+        // username=\"token\" password=\"%s\";", args.apikey));
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-        configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"token\" password=\"%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
                 args.apikey));
+        configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+                "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/token");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/keys");
         configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, args.bootstrapServers);
 
         // Set up the recommended Event Streams kafka producer configuration
-        // The client ID identifies your client application, and appears in the kafka server logs.
+        // The client ID identifies your client application, and appears in the kafka
+        // server logs.
         configs.put(CommonClientConfigs.CLIENT_ID_CONFIG, "eventstreams-java-sample-producer1");
-        // Setting acks to "all" means that the kafka server will not acknowledge receipt of a message until
-        // it has been distributed to all the brokers that are replicating the message. This is the strongest 
+        // Setting acks to "all" means that the kafka server will not acknowledge
+        // receipt of a message until
+        // it has been distributed to all the brokers that are replicating the message.
+        // This is the strongest
         // guarantee that messages will not be lost.
         configs.put(ProducerConfig.ACKS_CONFIG, "all");
-        // Setting retries to a non-zero value means that the apache client will try to resend messages
-        // on transient errors. This reduces the need for retry logic in the producer code/
+        // Setting retries to a non-zero value means that the apache client will try to
+        // resend messages
+        // on transient errors. This reduces the need for retry logic in the producer
+        // code/
         configs.put(ProducerConfig.RETRIES_CONFIG, 2147483647);
-        // Setting idempotence to true means that the apache client will guarantee that message send retries
+        // Setting idempotence to true means that the apache client will guarantee that
+        // message send retries
         // will not result in duplication of messages.
         configs.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
-        // With idempotence set to true, we must also configure the in-flight requests per connection to 5 or less.
+        // With idempotence set to true, we must also configure the in-flight requests
+        // per connection to 5 or less.
         configs.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
-        
+
         // The client can compress message data before it is transmitted. Typically the
         // trade-off between CPU and network bandwidth used makes this worthwhile.
         configs.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");
-        
+
         // Part of the producer's configuration is the classes to use for serializing
         // data into the records (message) that are sent from the client to Kafka.
         // In this sample, our keys and messages will both be strings.
         configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-		
-		return configs;
-	}
+
+        return configs;
+    }
 
 }

--- a/java-apache/07-logging/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
+++ b/java-apache/07-logging/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
@@ -48,7 +48,7 @@ public class ProducerConfiguration {
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
         configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=\"%s\";",
                 args.apikey));
         configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
                 "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");

--- a/java-apache/08-commit/consumer/.gitignore
+++ b/java-apache/08-commit/consumer/.gitignore
@@ -1,1 +1,2 @@
 /target/
+oauth-client/

--- a/java-apache/08-commit/consumer/pom.xml
+++ b/java-apache/08-commit/consumer/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.eventstreams</groupId>
             <artifactId>oauth-client</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
 
         <dependency>

--- a/java-apache/08-commit/consumer/pom.xml
+++ b/java-apache/08-commit/consumer/pom.xml
@@ -17,7 +17,13 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.1.0</version>
+            <version>3.3.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.eventstreams</groupId>
+            <artifactId>oauth-client</artifactId>
+            <version>0.1.1</version>
         </dependency>
 
         <dependency>

--- a/java-apache/08-commit/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
+++ b/java-apache/08-commit/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
@@ -22,45 +22,63 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
 /**
- * ConsumerConfiguration creates the configuration for the Apache Kafka consumer client.
- * See https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-consuming_messages for
+ * ConsumerConfiguration creates the configuration for the Apache Kafka consumer
+ * client.
+ * See
+ * https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-consuming_messages
+ * for
  * more information on configuring consumers for use with Event Streams.
  */
 public class ConsumerConfiguration {
 
-	public static Properties makeConfiguration(ConsumerCLI args) {
-		// The configuration for the apache client is a Properties, with keys defined in the apache client libraries.
-		final Properties configs = new Properties();
+    public static Properties makeConfiguration(ConsumerCLI args) {
+        // The configuration for the apache client is a Properties, with keys defined in
+        // the apache client libraries.
+        final Properties configs = new Properties();
 
-		// To access the kafka servers, we need to authenticate using SASL_SSL and the apikey,
-		// and provide the bootstrap server list
+        // To access the kafka servers, we need to authenticate using SASL_SSL and the
+        // apikey, and provide the bootstrap server list
+
+        // SASL_MECHANISM=PLAIN via API key is deprecated, use OAUTHBEARER instead
+        // configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+        // configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        // configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
+        // "org.apache.kafka.common.security.plain.PlainLoginModule required
+        // username=\"token\" password=\"%s\";", args.apikey));
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-        configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"token\" password=\"%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
                 args.apikey));
+        configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+                "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/token");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/keys");
         configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, args.bootstrapServers);
 
         // Set up the recommended Event Streams kafka consumer configuration
-        // The client ID identifies your client application, and appears in the kafka server logs.
+        // The client ID identifies your client application, and appears in the kafka
+        // server logs.
         configs.put(CommonClientConfigs.CLIENT_ID_CONFIG, "eventstreams-java-sample-consumer1");
-        
-        // Each consumer is a member of a consumer group, identified by a string (command-line argument
+
+        // Each consumer is a member of a consumer group, identified by a string
+        // (command-line argument
         // in this sample).
-	    configs.put(ConsumerConfig.GROUP_ID_CONFIG, args.consumerGroup);
-	    
-        // For this sample, new consumer groups will start reading messages at the earliest available offset.
+        configs.put(ConsumerConfig.GROUP_ID_CONFIG, args.consumerGroup);
+
+        // For this sample, new consumer groups will start reading messages at the
+        // earliest available offset.
         configs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        
+
         // Do not auto-commit
         configs.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
-	    
+
         // Part of the consumer's configuration is the classes to use for deserializing
         // data from the records (message) that are received by this consumer.
         // In this sample, we'll assume that the records contain strings.
         configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-	        
-	    return configs;
-	}
+
+        return configs;
+    }
 }

--- a/java-apache/08-commit/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
+++ b/java-apache/08-commit/consumer/src/main/java/com/ibm/eventstreams/ConsumerConfiguration.java
@@ -48,7 +48,7 @@ public class ConsumerConfiguration {
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
         configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=\"%s\";",
                 args.apikey));
         configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
                 "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");

--- a/java-apache/08-commit/producer/.gitignore
+++ b/java-apache/08-commit/producer/.gitignore
@@ -1,1 +1,2 @@
 /target/
+oauth-client/

--- a/java-apache/08-commit/producer/pom.xml
+++ b/java-apache/08-commit/producer/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.eventstreams</groupId>
             <artifactId>oauth-client</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
 
         <dependency>

--- a/java-apache/08-commit/producer/pom.xml
+++ b/java-apache/08-commit/producer/pom.xml
@@ -17,7 +17,13 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.1.0</version>
+            <version>3.3.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.eventstreams</groupId>
+            <artifactId>oauth-client</artifactId>
+            <version>0.1.1</version>
         </dependency>
 
         <dependency>

--- a/java-apache/08-commit/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
+++ b/java-apache/08-commit/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.ibm.eventstreams;
 
 import java.util.Properties;
@@ -23,52 +22,74 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 /**
- * ProducerConfiguration creates the configuration for the Apache Kafka producer client.
- * See https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-producing_messages for
+ * ProducerConfiguration creates the configuration for the Apache Kafka producer
+ * client.
+ * See
+ * https://cloud.ibm.com/docs/EventStreams?topic=EventStreams-producing_messages
+ * for
  * more information on configuring producers for use with Event Streams.
  */
 public class ProducerConfiguration {
-	
-	static Properties makeConfiguration(ProducerCLI args) {
-		// The configuration for the apache client is a Properties, with keys defined in the apache client libraries.
-		final Properties configs = new Properties();
-		
-		// To access the kafka servers, we need to authenticate using SASL_SSL and the apikey,
-		// and provide the bootstrap server list
+
+    static Properties makeConfiguration(ProducerCLI args) {
+        // The configuration for the apache client is a Properties, with keys defined in
+        // the apache client libraries.
+        final Properties configs = new Properties();
+
+        // To access the kafka servers, we need to authenticate using SASL_SSL and the
+        // apikey, and provide the bootstrap server list
+
+        // SASL_MECHANISM=PLAIN via API key is deprecated, use OAUTHBEARER instead
+        // configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+        // configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        // configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
+        // "org.apache.kafka.common.security.plain.PlainLoginModule required
+        // username=\"token\" password=\"%s\";", args.apikey));
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
-        configs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"token\" password=\"%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
                 args.apikey));
+        configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+                "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/token");
+        configs.put(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, "https://iam.cloud.ibm.com/identity/keys");
         configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, args.bootstrapServers);
 
         // Set up the recommended Event Streams kafka producer configuration
-        // The client ID identifies your client application, and appears in the kafka server logs.
+        // The client ID identifies your client application, and appears in the kafka
+        // server logs.
         configs.put(CommonClientConfigs.CLIENT_ID_CONFIG, "eventstreams-java-sample-producer0");
-        // Setting acks to "all" means that the kafka server will not acknowledge receipt of a message until
-        // it has been distributed to all the brokers that are replicating the message. This is the strongest 
+        // Setting acks to "all" means that the kafka server will not acknowledge
+        // receipt of a message until
+        // it has been distributed to all the brokers that are replicating the message.
+        // This is the strongest
         // guarantee that messages will not be lost.
         configs.put(ProducerConfig.ACKS_CONFIG, "all");
-        // Setting retries to a non-zero value means that the apache client will try to resend messages
-        // on transient errors. This reduces the need for retry logic in the producer code/
+        // Setting retries to a non-zero value means that the apache client will try to
+        // resend messages
+        // on transient errors. This reduces the need for retry logic in the producer
+        // code/
         configs.put(ProducerConfig.RETRIES_CONFIG, 2147483647);
-        // Setting idempotence to true means that the apache client will guarantee that message send retries
+        // Setting idempotence to true means that the apache client will guarantee that
+        // message send retries
         // will not result in duplication of messages.
         configs.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
-        // With idempotence set to true, we must also configure the in-flight requests per connection to 5 or less.
+        // With idempotence set to true, we must also configure the in-flight requests
+        // per connection to 5 or less.
         configs.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
-        
+
         // The client can compress message data before it is transmitted. Typically the
         // trade-off between CPU and network bandwidth used makes this worthwhile.
         configs.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");
-        
+
         // Part of the producer's configuration is the classes to use for serializing
         // data into the records (message) that are sent from the client to Kafka.
         // In this sample, our keys and messages will both be strings.
         configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-		
-		return configs;
-	}
+
+        return configs;
+    }
 
 }

--- a/java-apache/08-commit/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
+++ b/java-apache/08-commit/producer/src/main/java/com/ibm/eventstreams/ProducerConfiguration.java
@@ -48,7 +48,7 @@ public class ProducerConfiguration {
         configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
         configs.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
         configs.put(SaslConfigs.SASL_JAAS_CONFIG, String.format(
-                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=%s\";",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required grant_type=\"urn:ibm:params:oauth:grant-type:apikey\" apikey=\"%s\";",
                 args.apikey));
         configs.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
                 "com.ibm.eventstreams.oauth.client.IAMOAuthBearerLoginCallbackHandler");


### PR DESCRIPTION
- replaced `SASL_MECHANISM=PLAIN` with `SASL_MECHANISM=OAUTHBEARER` in all configurations together with other required properties, including: 
  - SASL_JAAS_CONFIG 
  - SASL_LOGIN_CALLBACK_HANDLER_CLASS
  - SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL 
  - SASL_OAUTHBEARER_JWKS_ENDPOINT_URL

In order not to confusion, plain config was commented out with deprecation notice instead of removed directly.

- updated pom.xml to add com.ibm.eventstreams:oauth-client:0.1.1 as a new dependency

- updated pom.xml to use the latest Kafka client to address CVE-2022-34917