### PR TITLE
Bump org.bitbucket.b_c.jose4j to 0.9.3

### DIFF
--- a/java-apache/oauth-client/pom.xml
+++ b/java-apache/oauth-client/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
-            <version>0.9.2</version>
+            <version>0.9.3</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Due to CVE-2023-31582